### PR TITLE
Disallow bot's usage of G51 IR

### DIFF
--- a/BWBP_SKC_Pro/Classes/G51Carbine.uc
+++ b/BWBP_SKC_Pro/Classes/G51Carbine.uc
@@ -55,7 +55,7 @@ simulated function OnWeaponParamsChanged()
 	bHasIR=false;
 	bSilenced=false;
 
-	if (InStr(WeaponParams.LayoutTags, "IR") != -1  && !(AIController(Instigator.Controller) != None))
+	if (InStr(WeaponParams.LayoutTags, "IR") != -1  && AIController(Instigator.Controller) == None)
 	{
 		bHasIR=true;
 		bThermal=true;

--- a/BWBP_SKC_Pro/Classes/G51Carbine.uc
+++ b/BWBP_SKC_Pro/Classes/G51Carbine.uc
@@ -55,7 +55,7 @@ simulated function OnWeaponParamsChanged()
 	bHasIR=false;
 	bSilenced=false;
 
-	if (InStr(WeaponParams.LayoutTags, "IR") != -1)
+	if (InStr(WeaponParams.LayoutTags, "IR") != -1  && !(AIController(Instigator.Controller) != None))
 	{
 		bHasIR=true;
 		bThermal=true;

--- a/BWBP_SKC_Pro/Classes/G51Carbine.uc
+++ b/BWBP_SKC_Pro/Classes/G51Carbine.uc
@@ -55,7 +55,7 @@ simulated function OnWeaponParamsChanged()
 	bHasIR=false;
 	bSilenced=false;
 
-	if (InStr(WeaponParams.LayoutTags, "IR") != -1  && AIController(Instigator.Controller) == None)
+	if (InStr(WeaponParams.LayoutTags, "IR") != -1)
 	{
 		bHasIR=true;
 		bThermal=true;
@@ -666,6 +666,9 @@ function byte BestMode()
 
 	B = Bot(Instigator.Controller);
 	if ( (B == None) || (B.Enemy == None) )
+		return 0;
+	
+	if (bHasIR == true)
 		return 0;
 
 	if (B.Skill > Rand(6))


### PR DESCRIPTION
Fixes bug where all players would be able to see in IR if a bot got it's hands on a G51 IR and alt-fired.